### PR TITLE
fix: correct firstName in error handling tutorial

### DIFF
--- a/knowledge/javascript-in-30-days/14_day_Error Handling_methods.md
+++ b/knowledge/javascript-in-30-days/14_day_Error Handling_methods.md
@@ -55,21 +55,21 @@ try {
 ```js
 try {
   let lastName = 'Yetayeh'
-  let fullName = fistName + ' ' + lastName
+  let fullName = firstName + ' ' + lastName
 } catch (err) {
   console.log(err)
 }
 ```
 
 ```sh
-ReferenceError: fistName is not defined
+ReferenceError: firstName is not defined
     at <anonymous>:4:20
 ```
 
 ```js
 try {
   let lastName = 'Yetayeh'
-  let fullName = fistName + ' ' + lastName
+  let fullName = firstName + ' ' + lastName
 } catch (err) {
   console.error(err) // we can use console.log() or console.error()
 } finally {
@@ -78,7 +78,7 @@ try {
 ```
 
 ```sh
-ReferenceError: fistName is not defined
+ReferenceError: firstName is not defined
     at <anonymous>:4:20
 In any case it  will be executed
 ```
@@ -86,7 +86,7 @@ The catch block take a parameter. It is common to pass e, err or error as a para
 ```js
 try {
   let lastName = 'Yetayeh'
-  let fullName = fistName + ' ' + lastName
+  let fullName = firstName + ' ' + lastName
 } catch (err) {
   console.log('Name of the error', err.name)
   console.log('Error message', err.message)
@@ -96,7 +96,7 @@ try {
 ```
 ```sh
 Name of the error ReferenceError
-Error message fistName is not defined
+Error message firstName is not defined
 In any case I will be executed
 ```
 throw: the throw statement allows us to create a custom error. We can through a string, number, boolean or an object. Use the throw statement to throw an exception. When you throw an exception, expression specifies the value of the exception. Each of the following throws an exception:


### PR DESCRIPTION
## Summary
- fix typo `fistName` -> `firstName` in Day 14 error handling lesson
- update sample ReferenceError messages to use `firstName`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_689c36bea38c8329b9584d11d6df10c2