### PR TITLE
Import expo-notifications in NotificationService

### DIFF
--- a/services/NotificationService.ts
+++ b/services/NotificationService.ts
@@ -1,5 +1,6 @@
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Notifications from 'expo-notifications';
 
 export class NotificationService {
   private static instance: NotificationService;


### PR DESCRIPTION
## Summary
- add expo-notifications module import to notification service

## Testing
- `npm run type-check` *(fails: TypeScript errors across repository)*
- `npm run test:pre-commit` *(fails: jest not installed; `npm install` could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689c36d3e6dc8329b567a0eb4b51b884