### PR TITLE
Connect explore tabs with JSON data

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -15,7 +15,7 @@ import * as Haptics from 'expo-haptics';
 
 import { useThemeColors } from '@/hooks/useThemeColors';
 import { useProgressStore } from '@/store/useProgressStore';
-import { designPatterns, codingQuestions, getAllLessons, getNotes, getQuizzes, getInterviewQuestions } from '@/data/processors/dataLoader';
+import { getAllLessons, getNotes, getQuizzes, getInterviewQuestions, getDesignPatterns, getCodingQuestions, getLearningRoadmap } from '@/data/processors/dataLoader';
 // Base explore cards template
 const baseExploreCards = [
   {
@@ -119,7 +119,7 @@ const baseExploreCards = [
     color: '#6366f1',
     route: '/(tabs)/explore/design-patterns',
     category: 'resource',
-    itemCount: designPatterns?.length || 0,
+    itemCount: 0,
     difficulty: 'advanced',
     estimatedTime: '45 min read'
   },
@@ -131,7 +131,7 @@ const baseExploreCards = [
     color: '#8b5cf6',
     route: '/(tabs)/explore/coding-questions',
     category: 'resource',
-    itemCount: codingQuestions?.length || 0,
+    itemCount: 0,
     difficulty: 'intermediate',
     estimatedTime: '30 min',
     isPopular: true
@@ -191,30 +191,32 @@ export default function ExploreScreen() {
   useEffect(() => {
     const loadDynamicCounts = async () => {
       try {
-        const [notes, quizzes, interviews, patterns, coding] = await Promise.all([
+        const [notes, quizzes, interviews, patterns, coding, roadmap] = await Promise.all([
           getNotes(),
           getQuizzes(),
           getInterviewQuestions(),
-          designPatterns || [],
-          codingQuestions || []
+          getDesignPatterns(),
+          getCodingQuestions(),
+          getLearningRoadmap()
         ]);
-        
+
         setDynamicCounts({
           'javascript-notes': notes.length,
           'practice-quiz': quizzes.length,
           'interview-prep': interviews.length,
-          'interview-quiz': Math.floor(interviews.length * 0.6), // Subset for advanced quiz
+          'interview-quiz': Math.floor(interviews.length * 0.6),
           'design-patterns': patterns.length,
           'coding-questions': coding.length,
-          'learning-roadmap': 6 // Static for now
+          'learning-roadmap': roadmap.nodes.length
         });
-        
+
         console.log('📊 Dynamic counts loaded:', {
           notes: notes.length,
           quizzes: quizzes.length,
           interviews: interviews.length,
           patterns: patterns.length,
-          coding: coding.length
+          coding: coding.length,
+          roadmap: roadmap.nodes.length
         });
       } catch (error) {
         console.error('Failed to load dynamic counts:', error);

--- a/app/(tabs)/explore/coding-questions/[id].tsx
+++ b/app/(tabs)/explore/coding-questions/[id].tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -16,15 +16,25 @@ import { getCodingQuestionById, CodingQuestion } from '@/data/processors/dataLoa
 export default function CodingQuestionDetailScreen() {
   const themeColors = useThemeColors();
   const { id } = useLocalSearchParams();
+  const [question, setQuestion] = useState<CodingQuestion | null>(null);
 
-  const question = getCodingQuestionById(id as string);
-  
+  useEffect(() => {
+    const loadQuestion = async () => {
+      try {
+        const data = await getCodingQuestionById(id as string);
+        setQuestion(data || null);
+      } catch (error) {
+        console.error('Failed to load coding question:', error);
+        setQuestion(null);
+      }
+    };
+    loadQuestion();
+  }, [id]);
+
   if (!question) {
     return (
       <View style={[styles.container, { backgroundColor: themeColors.background }]}>
-        <Text style={[styles.errorText, { color: themeColors.text }]}>
-          Question not found
-        </Text>
+        <Text style={[styles.errorText, { color: themeColors.text }]}>Question not found</Text>
       </View>
     );
   }

--- a/app/(tabs)/explore/design-patterns.tsx
+++ b/app/(tabs)/explore/design-patterns.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -10,13 +10,24 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, Code, Eye, Layers, Zap, ArrowRight } from 'lucide-react-native';
 import { useThemeColors } from '@/hooks/useThemeColors';
-import { designPatterns, DesignPattern, getDesignPatternsByCategory, getDesignPatternsByDifficulty } from '@/data/processors/dataLoader';
-
-// Use JSON data instead of hardcoded data
-const designPatternsData = designPatterns;
+import { getDesignPatterns, DesignPattern } from '@/data/processors/dataLoader';
 
 export default function DesignPatternsScreen() {
   const themeColors = useThemeColors();
+  const [patterns, setPatterns] = useState<DesignPattern[]>([]);
+
+  useEffect(() => {
+    const loadPatterns = async () => {
+      try {
+        const data = await getDesignPatterns();
+        setPatterns(data);
+      } catch (error) {
+        console.error('Failed to load design patterns:', error);
+        setPatterns([]);
+      }
+    };
+    loadPatterns();
+  }, []);
 
   const getDifficultyColor = (difficulty: string) => {
     switch (difficulty) {
@@ -112,7 +123,7 @@ export default function DesignPatternsScreen() {
 
         {/* Patterns List */}
         <View style={styles.patternsContainer}>
-          {designPatternsData?.map((pattern) => (
+          {patterns.map((pattern) => (
             <PatternCard key={pattern.id} pattern={pattern} />
           ))}
         </View>

--- a/app/(tabs)/explore/design-patterns/[id].tsx
+++ b/app/(tabs)/explore/design-patterns/[id].tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -16,16 +16,26 @@ import { getDesignPatternById, DesignPattern } from '@/data/processors/dataLoade
 export default function DesignPatternDetailScreen() {
   const themeColors = useThemeColors();
   const { id } = useLocalSearchParams();
+  const [pattern, setPattern] = useState<DesignPattern | null>(null);
 
-  const pattern = getDesignPatternById(id as string);
-  
+  useEffect(() => {
+    const loadPattern = async () => {
+      try {
+        const data = await getDesignPatternById(id as string);
+        setPattern(data || null);
+      } catch (error) {
+        console.error('Failed to load design pattern:', error);
+        setPattern(null);
+      }
+    };
+    loadPattern();
+  }, [id]);
+
   if (!pattern) {
     return (
-      <View style={[styles.container, { backgroundColor: themeColors.background }]}>
-        <Text style={[styles.errorText, { color: themeColors.text }]}>
-          Pattern not found
-        </Text>
-      </View>
+      <View style={[styles.container, { backgroundColor: themeColors.background }]}> 
+        <Text style={[styles.errorText, { color: themeColors.text }]}>Pattern not found</Text> 
+      </View> 
     );
   }
 

--- a/app/(tabs)/explore/interview-prep/[id].tsx
+++ b/app/(tabs)/explore/interview-prep/[id].tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -16,18 +16,28 @@ import Badge from '@/components/common/Badge';
 export default function InterviewPrepDetailScreen() {
   const themeColors = useThemeColors();
   const { id } = useLocalSearchParams();
+  const [question, setQuestion] = useState<any>(null);
 
-  const question = getInterviewQuestionById(id as string);
-  
+  useEffect(() => {
+    const loadQuestion = async () => {
+      try {
+        const data = await getInterviewQuestionById(id as string);
+        setQuestion(data || null);
+      } catch (error) {
+        console.error('Failed to load interview question:', error);
+        setQuestion(null);
+      }
+    };
+    loadQuestion();
+  }, [id]);
+
   if (!question) {
     return (
       <ScrollableContentPage
         title="Question not found"
         backRoute="/(tabs)/explore/interview-prep"
       >
-        <Text style={[styles.errorText, { color: themeColors.text }]}>
-          Question not found
-        </Text>
+        <Text style={[styles.errorText, { color: themeColors.text }]}>Question not found</Text>
       </ScrollableContentPage>
     );
   }

--- a/app/(tabs)/explore/learning-roadmap.tsx
+++ b/app/(tabs)/explore/learning-roadmap.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -11,79 +11,27 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { ArrowLeft, CheckCircle, Circle, ArrowDown, Code, Database, Globe } from 'lucide-react-native';
 import { useThemeColors } from '@/hooks/useThemeColors';
+import { getLearningRoadmap, LearningRoadmap } from '@/data/processors/dataLoader';
 
 const { width } = Dimensions.get('window');
-
-// Roadmap data structure
-const roadmapData = [
-  {
-    id: 'basics',
-    title: 'JavaScript Basics',
-    description: 'Variables, data types, operators',
-    icon: 'code',
-    status: 'completed',
-    topics: ['Variables', 'Data Types', 'Operators', 'Functions'],
-    estimatedTime: '2 weeks'
-  },
-  {
-    id: 'dom',
-    title: 'DOM Manipulation',
-    description: 'Interact with web pages',
-    icon: 'globe',
-    status: 'completed',
-    topics: ['Selecting Elements', 'Event Handling', 'Dynamic Content'],
-    estimatedTime: '1 week'
-  },
-  {
-    id: 'async',
-    title: 'Asynchronous JavaScript',
-    description: 'Promises, async/await, callbacks',
-    icon: 'code',
-    status: 'in-progress',
-    topics: ['Callbacks', 'Promises', 'Async/Await', 'Fetch API'],
-    estimatedTime: '2 weeks'
-  },
-  {
-    id: 'es6',
-    title: 'ES6+ Features',
-    description: 'Modern JavaScript features',
-    icon: 'code',
-    status: 'locked',
-    topics: ['Arrow Functions', 'Destructuring', 'Modules', 'Classes'],
-    estimatedTime: '1 week'
-  },
-  {
-    id: 'frameworks',
-    title: 'Frontend Frameworks',
-    description: 'React, Vue, Angular',
-    icon: 'globe',
-    status: 'locked',
-    topics: ['React Basics', 'Component Lifecycle', 'State Management'],
-    estimatedTime: '4 weeks'
-  },
-  {
-    id: 'backend',
-    title: 'Backend Development',
-    description: 'Node.js, Express, APIs',
-    icon: 'database',
-    status: 'locked',
-    topics: ['Node.js', 'Express.js', 'REST APIs', 'Database Integration'],
-    estimatedTime: '3 weeks'
-  },
-  {
-    id: 'advanced',
-    title: 'Advanced Concepts',
-    description: 'Performance, testing, deployment',
-    icon: 'code',
-    status: 'locked',
-    topics: ['Testing', 'Performance', 'Security', 'Deployment'],
-    estimatedTime: '2 weeks'
-  }
-];
 
 export default function LearningRoadmapScreen() {
   const themeColors = useThemeColors();
   const [selectedNode, setSelectedNode] = useState<string | null>(null);
+  const [nodes, setNodes] = useState<any[]>([]);
+
+  useEffect(() => {
+    const loadRoadmap = async () => {
+      try {
+        const data = await getLearningRoadmap();
+        setNodes(data.nodes || []);
+      } catch (error) {
+        console.error('Failed to load learning roadmap:', error);
+        setNodes([]);
+      }
+    };
+    loadRoadmap();
+  }, []);
 
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -114,7 +62,7 @@ export default function LearningRoadmapScreen() {
 
   const RoadmapNode = ({ node, index }: { node: any; index: number }) => {
     const StatusIcon = getStatusIcon(node.status);
-    const NodeIcon = getNodeIcon(node.icon);
+    const NodeIcon = getNodeIcon(node.icon || 'code');
     const isSelected = selectedNode === node.id;
     const isEven = index % 2 === 0;
 
@@ -201,7 +149,7 @@ export default function LearningRoadmapScreen() {
         )}
 
         {/* Arrow to next node */}
-        {index < roadmapData.length - 1 && (
+        {index < nodes.length - 1 && (
           <View style={styles.arrowContainer}>
             <ArrowDown size={24} color={themeColors.textSecondary} />
           </View>
@@ -234,20 +182,18 @@ export default function LearningRoadmapScreen() {
 
         {/* Progress Overview */}
         <View style={[styles.progressOverview, { backgroundColor: themeColors.card }]}>
-          <Text style={[styles.progressTitle, { color: themeColors.text }]}>
-            Your Progress
-          </Text>
+          <Text style={[styles.progressTitle, { color: themeColors.text }]}>Your Progress</Text>
           <View style={styles.progressStats}>
             <View style={styles.progressStat}>
-              <Text style={[styles.progressNumber, { color: '#10b981' }]}>2</Text>
+              <Text style={[styles.progressNumber, { color: '#10b981' }]}>{nodes.filter(n => n.status === 'completed').length}</Text>
               <Text style={[styles.progressLabel, { color: themeColors.textSecondary }]}>Completed</Text>
             </View>
             <View style={styles.progressStat}>
-              <Text style={[styles.progressNumber, { color: '#f59e0b' }]}>1</Text>
+              <Text style={[styles.progressNumber, { color: '#f59e0b' }]}>{nodes.filter(n => n.status === 'current' || n.status === 'in-progress').length}</Text>
               <Text style={[styles.progressLabel, { color: themeColors.textSecondary }]}>In Progress</Text>
             </View>
             <View style={styles.progressStat}>
-              <Text style={[styles.progressNumber, { color: themeColors.textSecondary }]}>4</Text>
+              <Text style={[styles.progressNumber, { color: themeColors.textSecondary }]}>{nodes.filter(n => n.status === 'locked').length}</Text>
               <Text style={[styles.progressLabel, { color: themeColors.textSecondary }]}>Remaining</Text>
             </View>
           </View>
@@ -255,7 +201,7 @@ export default function LearningRoadmapScreen() {
 
         {/* Roadmap */}
         <View style={styles.roadmapContainer}>
-          {roadmapData?.map((node, index) => (
+          {nodes.map((node, index) => (
             <RoadmapNode key={node.id} node={node} index={index} />
           ))}
         </View>


### PR DESCRIPTION
## Summary
- Load explore screen counts for notes, quizzes, interview questions, design patterns, coding questions, and roadmap nodes directly from JSON data
- Fetch design patterns, coding questions, and learning roadmap content asynchronously in their respective explore tabs
- Resolve detail screens for coding questions, design patterns, and interview prep asynchronously to avoid broken links

## Testing
- `npm install` *(fails: ERESOLVE could not resolve peer dependencies)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c3893b10c832984b349c8dd21ed54